### PR TITLE
fix PayloadTooLargeError

### DIFF
--- a/localturk.ts
+++ b/localturk.ts
@@ -8,7 +8,6 @@
  *   localturk [--options] template.html tasks.csv outputs.csv
  */
 
-import * as bodyParser from 'body-parser';
 import * as errorhandler from 'errorhandler';
 import * as express from 'express';
 import * as fs from 'fs-extra';
@@ -159,8 +158,9 @@ async function getNextTask(): Promise<TaskStats> {
 }
 
 const app = express();
-app.use(bodyParser.urlencoded({extended: false}));
 app.use(errorhandler());
+app.use(express.json({limit: "50mb"}));
+app.use(express.urlencoded({limit: "50mb", extended: true, parameterLimit:50000}));
 app.use(express.static(path.resolve(staticDir)));
 
 app.get('/', utils.wrapPromise(async (req, res) => {


### PR DESCRIPTION
I was getting a `PayloadTooLargeError` in certain cases. Per this [stackoverflow](https://stackoverflow.com/a/68189263/5712749) answer, I switched from body-parser to express.

I have not run any extensive testing, but this did fix the problem.