### PR TITLE
classify-image improvements

### DIFF
--- a/classify-images.ts
+++ b/classify-images.ts
@@ -75,8 +75,13 @@ if (images.length === 1 && images[0].endsWith('.txt')) {
   fs.writeSync(csvInfo.fd, 'path\n');
   fs.writeSync(csvInfo.fd, fs.readFileSync(images[0], 'utf8'));
 } else {
-  staticDir = path.dirname(images[0]);
-  images = images.map(p => path.relative(staticDir!, p));
+  const anyOutsideCwd = images.some(p => path.isAbsolute(p) || p.startsWith('..'));
+  if (anyOutsideCwd) {
+    staticDir = path.dirname(images[0]);
+    images = images.map(p => path.relative(staticDir!, p));
+  } else {
+    staticDir = '.';
+  }
   fs.writeSync(csvInfo.fd, 'path\n' + images.join('\n') + '\n');
 }
 fs.closeSync(csvInfo.fd);

--- a/localturk.ts
+++ b/localturk.ts
@@ -43,6 +43,7 @@ interface CLIArgs {
 
 const program = new Command();
 
+// If you add an option here, consider adding it in classify-images.ts as well.
 program
   .version('2.1.1')
   .usage('[options] template.html tasks.csv outputs.csv')


### PR DESCRIPTION
Fixes #29 
Fixes #30 

If you pass a path that's absolute or outside the current directory, all images are assumed to be in the same directory, which is used as the static dir. A more complete solution would be something like [common-path](https://www.npmjs.com/package/common-path).