### PR TITLE
Add /:num endpoint

### DIFF
--- a/localturk.ts
+++ b/localturk.ts
@@ -202,9 +202,8 @@ async function getTaskNum(n: number): Promise<TaskStats> {
   const completedTasks = await readCompletedTasks();  // just getting the count.
   let i = 0;
   let numTotal = 0;
-  let taskN;;
+  let taskN;
   for await (const task of csv.readRowObjects(tasksFile)) {
-    task.ROW_NUMBER = String(numTotal + 1);
     numTotal++;
     if (i === n) {
       taskN = task;


### PR DESCRIPTION
This is helpful if you want to iterate on your template with a particular input, especially if you found that input with `--random-order`.

Helps with #39 -- that envisions making `/` redirect to `/:num`, which I still think is a good idea but is a little more than I want to do in this PR.